### PR TITLE
zmq conditional version install for python 3.11 compatibility

### DIFF
--- a/parqueryd/__init__.py
+++ b/parqueryd/__init__.py
@@ -3,7 +3,7 @@ import logging
 # from version import __version__
 
 pre_release_version = os.getenv('PRE_RELEASE_VERSION', '')
-__version__ = '1.0.2{}'.format(pre_release_version)
+__version__ = '1.0.3{}'.format(pre_release_version)
 
 # initalize logger
 logger = logging.getLogger('parqueryd')

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ install_requires = [
     'parquery~=0.5.1;python_version=="2.7"',
     'parquery>=1.0.2;python_version>="3.7"',
     'psutil>=5.7.2',
-    'pyzmq==19.0.2',
+    'pyzmq==19.0.2;python_version<"3.11"',
+    'pyzmq==25.1.2;python_version>="3.11"',
     'redis>=3.5',
     "sentry-sdk",
     'smart-open>=1.11.1'


### PR DESCRIPTION
zmq version 19.0.2 fails in Python 3.11. See: https://app.circleci.com/pipelines/github/visualfabriq/api/68637/workflows/0478d226-89a1-4dee-bd44-2517e11c9336/jobs/216622

This will install latest stable version of zmq if python version is >= 3.11